### PR TITLE
fix: move version

### DIFF
--- a/archspec/compspec.json
+++ b/archspec/compspec.json
@@ -1,7 +1,7 @@
 {
     "compatibilities": {
-        "version": "0.0.0",
         "io.archspec.cpu": { 
+             "version": "0.0.0",
              "annotations": [
                  "family",
                  "model",

--- a/definition-schema.json
+++ b/definition-schema.json
@@ -6,13 +6,13 @@
   "properties": {
     "compatibilities": {
       "type": "object",
-      "properties": {
-        "version": {
-          "$comment": "Version of the metadata namespace",
-          "type": "string"
-        },
-        "patternProperties": {
-          "([\\w]*)": {
+      "patternProperties": {
+        "([\\w]*)": {
+          "properties": {
+            "version": {
+              "$comment": "Version of the metadata namespace",
+              "type": "string"
+            },
             "annotations": {
               "$comment": "Acceptable keys for a given namespace.",
               "type": "array",

--- a/schema.json
+++ b/schema.json
@@ -6,13 +6,13 @@
   "properties": {
     "compatibilities": {
       "type": "object",
-      "properties": {
-        "version": {
-          "$comment": "Version of the metadata namespace",
-          "type": "string"
-        },
-        "patternProperties": {
-          "([\\w]*)": {
+      "patternProperties": {
+        "([\\w]*)": {
+          "properties": {
+            "version": {
+              "$comment": "Version of the metadata namespace",
+              "type": "string"
+            },
             "annotations": {
               "$comment": "Key value pairs for a given namespace.",
               "type": "array",

--- a/supercontainers/compspec.json
+++ b/supercontainers/compspec.json
@@ -1,7 +1,7 @@
 {
     "compatibilities": {
-        "version": "0.0.0",
         "org.supercontainers.mpi": { 
+             "version": "0.0.0",
              "annotations": [
                  "implementation",
                  "portability.optimization",
@@ -9,6 +9,7 @@
              ]
          },
         "org.supercontainers.hardware.gpu": { 
+             "version": "0.0.0",
              "annotations": [
                  "driver.version",
                  "cuda.version",
@@ -16,16 +17,19 @@
              ]
          },
         "org.supercontainers.communication": { 
+             "version": "0.0.0",
              "annotations": [
                  "framework"
              ]
          },
         "org.supercontainers.openmpi": { 
+             "version": "0.0.0",
              "annotations": [
                  "version"
              ]
          },
         "org.supercontainers.libfabric": { 
+             "version": "0.0.0",
              "annotations": [
                  "abi.version"
              ]


### PR DESCRIPTION
Problem: a compatibility manifest can combine several different namespaces (and thus compatibility interest groups) labels, and each would carry its own version. Right now version is at the top level of the entire set.
Solution: move version down to belong within a namespace