### PR TITLE
simplify MPI

### DIFF
--- a/supercontainers/compspec.json
+++ b/supercontainers/compspec.json
@@ -4,6 +4,7 @@
              "version": "0.0.0",
              "annotations": [
                  "implementation",
+                 "version",
                  "portability.optimization",
                  "porability.mode"
              ]
@@ -20,12 +21,6 @@
              "version": "0.0.0",
              "annotations": [
                  "framework"
-             ]
-         },
-        "org.supercontainers.openmpi": { 
-             "version": "0.0.0",
-             "annotations": [
-                 "version"
              ]
          },
         "org.supercontainers.libfabric": { 


### PR DESCRIPTION
I think we should start simple, assuming an environment has one MPI implementation and version. I also do not like hardcoding specific library names into the labels themselves. With this tweak we will define a main MPI implementation and version, and we can expand upon that if/when it is absolutely needed. Likely a set of labels that are very library/software specific also need to belong to a package manager and not the generic set that we have here.